### PR TITLE
Revert breaking compatibility with Coq <8.12

### DIFF
--- a/src/DblibTactics.v
+++ b/src/DblibTactics.v
@@ -3,10 +3,9 @@ Require Import Compare_dec.
 Require Import Peano_dec.
 Require Import Lia.
 
-(* Logical hints *)
+(* A hint for invoking [f_equal] as part of [eauto] search. *)
 
-Hint Extern 1 => f_equal : logic.
-Hint Extern 3 => firstorder : logic.
+Hint Extern 1 => f_equal : f_equal.
 
 (* Hints for invoking omega on arithmetic subgoals. *)
 

--- a/src/DeBruijn.v
+++ b/src/DeBruijn.v
@@ -1497,32 +1497,28 @@ Ltac prove_traverse_var_injective :=
   let t1 := fresh "t1" in
   intros ? ? t1; induction t1;
   let t2 := fresh "t2" in
-  intro t2; destruct t2; cbn;
+  intro t2; destruct t2; simpl;
   let h := fresh "h" in
   intros ? h; inversion h;
   f_equal;
-  eauto using @traverse_var_injective with typeclass_instances;
-  firstorder;
-  try congruence.
+  eauto using @traverse_var_injective with typeclass_instances.
   (* The lemma [traverse_var_injective] can be useful if the [traverse]
      function at hand calls another [traverse] function which has already
      been proved injective. *)
 
 Ltac prove_traverse_functorial :=
   let t := fresh "t" in
-  intros ? ? t; induction t; intros; cbn;
-  f_equal; eauto using @traverse_functorial with typeclass_instances;
-  firstorder.
+  intros ? ? t; induction t; intros; simpl;
+  f_equal; eauto using @traverse_functorial with typeclass_instances.
 
 Ltac prove_traverse_relative :=
   let t := fresh "t" in
-  intros ? ? ? t; induction t; intros; subst; cbn;
-  eauto using @traverse_relative with logic lia typeclass_instances.
+  intros ? ? ? t; induction t; intros; subst; simpl;
+  eauto using @traverse_relative with f_equal lia typeclass_instances.
 
 Ltac prove_traverse_var_is_identity :=
-  intros ? ? t; induction t; intros; cbn;
-  f_equal; eauto using @traverse_var_is_identity with typeclass_instances;
-  firstorder.
+  intros ? ? t; induction t; intros; simpl;
+  f_equal; eauto using @traverse_var_is_identity with typeclass_instances.
 
 (* ------------------------------------------------------------------------------ *)
 

--- a/src/Environments.v
+++ b/src/Environments.v
@@ -524,7 +524,7 @@ Lemma map_map_fuse:
 Proof.
   induction e; intros;
     try match goal with o: option _ |- _ => destruct o end;
-    simpl; eauto with logic.
+    simpl; eauto with f_equal.
 Qed.
 
 Lemma map_map_exchange:
@@ -534,7 +534,7 @@ Lemma map_map_exchange:
 Proof.
   induction e; intros;
     try match goal with o: option _ |- _ => destruct o end;
-    simpl; eauto with logic.
+    simpl; eauto with f_equal.
 Qed.
 
 Lemma map_lift_map_lift:
@@ -566,7 +566,7 @@ Lemma map_map_vanish:
 Proof.
   induction e; intros;
     try match goal with o: option _ |- _ => destruct o end;
-    simpl; eauto with logic.
+    simpl; eauto with f_equal.
 Qed.
 
 (* ---------------------------------------------------------------------------- *)
@@ -1124,7 +1124,7 @@ Proof.
   induction n; intros; subst; destruct e2; simpl in *; try discriminate; auto.
 - rewrite insert_insert by lia.
   erewrite <- (IHn (1 + x)) by first [ congruence | eauto ].
-  eauto with logic lia.
+  eauto with f_equal lia.
 Qed.
 
 Lemma concat_app:

--- a/tests/bugs/opened/bug_9.v
+++ b/tests/bugs/opened/bug_9.v
@@ -34,17 +34,20 @@ Module weird_traverse1.
   Instance TraverseVarInjective_term : @TraverseVarInjective term _ term _.
     constructor.
     prove_traverse_var_injective.
-  Qed.
+  Fail Qed.
+  Abort.
 
   Instance Traverse_term_functorial : @TraverseFunctorial term _ term _.
     constructor.
     prove_traverse_functorial.
-  Qed.
+  Fail Qed.
+  Abort.
 
   Instance TraverseRelative_term : @TraverseRelative term term _.
     constructor.
     prove_traverse_relative.
-  Qed.
+  Fail Qed.
+  Abort.
 
   Instance TraverseIdentifiesVar_term : @TraverseIdentifiesVar term _ _.
     constructor.
@@ -54,5 +57,6 @@ Module weird_traverse1.
   Instance TraverseVarIsIdentity_term : @TraverseVarIsIdentity term _ term _.
     constructor.
     prove_traverse_var_is_identity.
-  Qed.
+  Fail Qed.
+  Abort.
 End weird_traverse1.


### PR DESCRIPTION
In an attempt to fix #9, I wrote 7ea22c0c36455895ecdbeec6966522b9653733f9. However, that broke compatibility with Coq<8.12 because `firstorder` and `intuition` sometimes consume inordinate amounts of RAM. Revert that commit, and move `weird_traverses.v` to the `bugs/opened` directory now that #9 is open